### PR TITLE
Fix the Skolem trick with GHC ≥ 9.4

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ghc: ['8.4.4', '8.6.5', '8.8.4', '8.10.7', '9.0.2', '9.6.1']
+        ghc: ['8.4.4', '8.6.5', '8.8.4', '8.10.7', '9.0.2', '9.2.5', '9.4.5', '9.6.1']
         os: ['ubuntu-latest', 'macos-latest']
     runs-on: ${{ matrix.os }}
 

--- a/dependent-sum-template.cabal
+++ b/dependent-sum-template.cabal
@@ -19,6 +19,8 @@ tested-with:            GHC == 8.4.4,
                         GHC == 8.8.4,
                         GHC == 8.10.7,
                         GHC == 9.0.2,
+                        GHC == 9.2.5,
+                        GHC == 9.4.5,
                         GHC == 9.6.1
 
 extra-source-files:     ChangeLog.md


### PR DESCRIPTION
Using a data family instead of a type family weirdly prevents the `Skolem` constructor from being treated as a metavariable, see https://gitlab.haskell.org/ghc/ghc/-/issues/23743#note_522186

Backlog: https://github.com/obsidiansystems/dependent-sum-template/pull/2#issuecomment-1649439589

@ali-abrar @cgibbard 