### PR TITLE
Support ghc-9.8

### DIFF
--- a/dependent-sum-template.cabal
+++ b/dependent-sum-template.cabal
@@ -41,7 +41,7 @@ Library
                         some >= 1.0.1 && < 1.1,
                         containers >= 0.5.9.2,
                         mtl,
-                        template-haskell >= 2.11 && < 2.21,
+                        template-haskell >= 2.11 && < 2.23,
                         th-abstraction >= 0.4
 
 test-suite test


### PR DESCRIPTION
This depends on at least the version of `some` in https://github.com/haskellari/some/pull/58 .

To test compiling this I added a `cabal.project` file containing:
```
packages:
  .

allow-newer:
  , some:base
  , some:deepseq
``